### PR TITLE
PMQ-1508: Create Github Action for publishing packages on Gradle projects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM adoptopenjdk:11-jre-hotspot
+
+RUN apt update
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Gradle Publish Package Action
+
+## Overview
+
+This action can be used in a Github workflow of a Gradle project
+to publish a package to Github Packages.
+
+## Usage
+
+Use this action within a Github workflow, e.g. `.github/workflows/publish.yml`
+
+```
+name: Publish package to GitHub Packages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: university-of-york/esg-action-gradle-publish-package
+        with:
+          gradle-tasks: wrapper clean check publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Your project will need to be a Gradle project, with the `gradlew` script in the
+root folder (make sure it is executable), and with `build.gradle`
+[configured for publishing to Github Packages](https://docs.github.com/en/actions/guides/publishing-java-packages-with-gradle#publishing-packages-to-github-packages). 
+
+Example:
+
+```
+publishing {
+    repositories {
+        maven {
+            name = "Github"
+            url = uri("https://maven.pkg.github.com/university-of-york/<package name>")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+    publications {
+        maven(MavenPublication) {
+            from components.java
+            artifact sourcesJar
+        }
+    }
+}
+```

--- a/README.md
+++ b/README.md
@@ -3,11 +3,18 @@
 ## Overview
 
 This action can be used in a Github workflow of a Gradle project
-to publish a package to Github Packages.
+to publish a package (e.g. to Github Packages).
+
+It will run the Gradle tasks in a Java 11 environment.
 
 ## Usage
 
-Use this action within a Github workflow, e.g. `.github/workflows/publish.yml`
+Your project will need to be a Gradle project, with the `gradlew` script in the
+root folder. Make sure `gradlew` is executable.
+
+Use this action within a Github workflow. For example:
+
+**`.github/workflows/publish.yml`**
 
 ```
 name: Publish package to GitHub Packages
@@ -23,17 +30,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: university-of-york/esg-action-gradle-publish-package
-        with:
-          gradle-tasks: wrapper clean check publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-Your project will need to be a Gradle project, with the `gradlew` script in the
-root folder (make sure it is executable), and with `build.gradle`
-[configured for publishing to Github Packages](https://docs.github.com/en/actions/guides/publishing-java-packages-with-gradle#publishing-packages-to-github-packages). 
+By default, this action will run the tasks 
 
-Example:
+```clean check publish --refresh-dependencies```
+
+Optionally, you can specify an alternative list of Gradle tasks to run:
+
+```
+      - uses: university-of-york/esg-action-gradle-publish-package
+        with:
+          tasks: clean build publish
+```
+
+This action assumes that `build.gradle` has been configured to publish a package
+[(e.g. to Github Packages)](https://docs.github.com/en/actions/guides/publishing-java-packages-with-gradle#publishing-packages-to-github-packages)
 
 ```
 publishing {

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,13 @@
+name: "Gradle publish package"
+description: "Publish a package for a Gradle project"
+
+inputs:
+  tasks:
+    description: "Gradle tasks/commands to run (including any command line switches/arguments)"
+    required: false
+
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ${{ inputs.tasks }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Run Gradle tasks to publish a package
+
+# Use the supplied list of Gradle tasks to run if given
+# or if not use a default list of Gradle tasks
+DEFAULT_TASK_LIST="clean check publish --refresh-dependencies"
+TASK_LIST=${1:-$DEFAULT_TASK_LIST}
+
+./gradlew $TASK_LIST


### PR DESCRIPTION
This Github Action will reduce the amount of code needed to publish a package within a Github workflow. It should allow the publishing part to be done in one line (for most projects).

Before:
```
    steps:
      - uses: actions/checkout@v2
      - uses: actions/setup-java@v1
        with:
          java-version: 11.0.x
      - name: Run tests and publish
        run: ./gradlew wrapper clean check publish
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
After:
```
    steps:
      - uses: actions/checkout@v2
      - uses: university-of-york/esg-action-gradle-publish-package@1.0.0
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```